### PR TITLE
Increase nginx timeouts

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -28,6 +28,10 @@ http {
             auth_basic "Restricted";
             auth_basic_user_file docker-registry.htpasswd;
             proxy_pass http://docker-registry;
+            proxy_connect_timeout       300;
+            proxy_send_timeout          300;
+            proxy_read_timeout          300;
+            send_timeout                300;
         }
 
         location /_ping {


### PR DESCRIPTION
This seems to be necessary when uploading really large layers.
