### PR TITLE
Remove cloudfront config

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,10 +12,6 @@ ADD nginx.conf /etc/nginx/nginx.conf
 ADD run-nginx /usr/local/bin/run-nginx
 RUN chmod 755 /usr/local/bin/run-nginx
 
-# Add support for cloudfront
-ADD additional-config.conf additional-config.conf
-RUN cat additional-config.conf >> /docker-registry/config/config_sample.yml
-
 ENV SETTINGS_FLAVOR prod
 ENV WORKER_SECRET_KEY fsekfhefsefefe
 

--- a/additional-config.conf
+++ b/additional-config.conf
@@ -1,7 +1,0 @@
-cloudfronts3: &cloudfronts3
-    <<: *s3
-    storage_path: _env:STORAGE_PATH:/prod
-    cloudfront:
-        base: _env:CF_BASE_URL
-        keyid: _env:CF_KEYID
-        keysecret: _env:CF_KEYSECRET


### PR DESCRIPTION
We're not using the cloudfront config and it seems to cause problems for
some unknown reason. We might as well get rid of it.
